### PR TITLE
tidy up form markup for registration process

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,23 +8,3 @@ if (window.console && window.console.info) {
 $(document).ready(function () {
   window.GOVUKFrontend.initAll()
 })
-
-// Check if radio button has been selected
-const radioButton = $("input[value$='Yes']")
-if(!radioButton.attr('checked')) {
-  $("div.input-box").hide()
-}
-
-// toggle input div based on selected option
-$(document).ready(function() {
-  $("input[type$='radio']").click(function() {
-    
-    const buttonValue = $(this).val();
-      if(buttonValue === "No") {
-        $("div.input-box").hide()
-      } else {
-        $("div.input-box").show()
-      }
-      
-  });
-});

--- a/app/views/v1/home-test-kit/confirmation-page.html
+++ b/app/views/v1/home-test-kit/confirmation-page.html
@@ -3,7 +3,7 @@
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  We've recieved your order - GOV.UK
+  We've received your order - GOV.UK
 {% endblock %}
 
 {% block content %}
@@ -11,7 +11,7 @@
     <div class="govuk-grid-column-two-thirds">
 
       <div class="govuk-panel govuk-panel--confirmation govuk-!-padding-8 govuk-!-margin-bottom-8">
-        <h1 class="govuk-panel__title">We've recieved your order</h1>
+        <h1 class="govuk-panel__title">We've received your order</h1>
         <div class="govuk-panel__body">
           You'll receive an email soon to confirm if your order was succesfully processed
         </div>
@@ -21,7 +21,7 @@
       <p class="govuk-body">If your order was succesfull, we'll send your coronavirus home test kit to you.</p>
       <p class="govuk-body">The test kit contains a swab, instructions on how to use it, and return packaging.</p>
       <p class="govuk-body">It should arrive at the addresss you gave us in the next 48 hours.</p>
-      <p class="govuk-body">You'll recieve email updates on the delivery statuss of your home test kit.</p>
+      <p class="govuk-body">You'll receive email updates on the delivery statuss of your home test kit.</p>
       <p class="govuk-body">If your order was not succesfull, we'll send you an email with what to do next.</p>
 
       <h2 class="govuk-heading-m">Once you get your test kit</h2>

--- a/app/views/v1/registration/blood-sample.html
+++ b/app/views/v1/registration/blood-sample.html
@@ -1,11 +1,13 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  Are you able to provide blood? - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/v1/registration/test-selection">Back</a>
+  <a class="govuk-back-link" href="/{{version}}/registration/test-selection">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -13,27 +15,30 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Are you able to provide blood?</h1>
-
-      <p class="govuk-body-m">The antibody test involves drawing blood. You will not be able to take an antibody test if you are not able to draw blood, for example because you have haemophilia.</p>
-
-      <p class="govuk-body-m">If you are unable to self-administer the blood test, you should…</p>
-
-      <form class="form" action="/v1/registration/name" method="post">
+      <form action="/{{version}}/registration/name" method="post">
 
         <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset">
+          <fieldset class="govuk-fieldset" aria-describedby="blood-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                Are you able to provide blood?
+              </h1>
+            </legend>
+            <span id="blood-hint" class="govuk-hint">
+              The antibody test involves drawing blood. You will not be able to take an antibody test if you are not able to draw blood, for example because you have haemophilia.<br><br>
+              If you are unable to self-administer the blood test, you should…
+            </span>
             <div class="govuk-radios">
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="blood-sample-1" name="blood-sample" type="radio" value="Yes" {{ checked("blood-sample", "Yes") }}>
                 <label class="govuk-label govuk-radios__label" for="blood-sample-1">
-                    Yes, I am able to provide blood
+                  Yes, I am able to provide blood
                 </label>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="blood-sample-2" name="blood-sample" type="radio" value="No" {{ checked("blood-sample", "No") }}>
                 <label class="govuk-label govuk-radios__label" for="blood-sample-2">
-                    No, I am not able to provide blood
+                  No, I am not able to provide blood
                 </label>
               </div>
             </div>

--- a/app/views/v1/registration/check-your-answers.html
+++ b/app/views/v1/registration/check-your-answers.html
@@ -1,11 +1,13 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Check your answers
+  Check your answers - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/v1/registration/postcode">Back</a>
+  <a class="govuk-back-link" href="/{{version}}/registration/postcode">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -162,7 +164,7 @@
             Postcode
           </dt>
           <dd class="govuk-summary-list__value">
-            {{ data['postcode'] }}
+            {{ data['test-postcode'] }}
           </dd>
           <dd class="govuk-summary-list__actions">
             <a href="/v1/registration/postcode">

--- a/app/views/v1/registration/confirmation.html
+++ b/app/views/v1/registration/confirmation.html
@@ -13,8 +13,6 @@
         <h1 class="govuk-panel__title">Antibody test application completed</h1>
       </div>
 
-      <br>
-
       <h2 class="govuk-heading-m">What happens next</h2>
 
       <p>There is currently a waiting list for antibody tests. Please note that it could be several weeks before you are allocated a test.</p>

--- a/app/views/v1/registration/date-of-birth.html
+++ b/app/views/v1/registration/date-of-birth.html
@@ -1,11 +1,13 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  What's your date of birth? - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/v1/registration/name">Back</a>
+  <a class="govuk-back-link" href="/{{version}}/registration/name">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -13,15 +15,17 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">What's your date of birth?</h1>
-
-      <p class="govuk-body-m">If you're ordering a test for someone else, enter their date of birth.</p>
-
-      <form class="form" action="/v1/registration/mobile-number" method="post">
+      <form action="/{{version}}/registration/mobile-number" method="post">
 
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset" role="group" aria-describedby="date-of-birth-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                What's your date of birth?
+              </h1>
+            </legend>
             <span id="date-of-birth-hint" class="govuk-hint">
+              If you're ordering a test for someone else, enter their date of birth.<br><br>
               For example, 19 7 1986
             </span>
             <div class="govuk-date-input" id="date-of-birth">

--- a/app/views/v1/registration/do-you-have-symptoms.html
+++ b/app/views/v1/registration/do-you-have-symptoms.html
@@ -1,11 +1,13 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  Do you currently have coronavirus symptoms? - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/v1/registration/index">Back</a>
+  <a class="govuk-back-link" href="/{{version}}/registration/">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -13,23 +15,25 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Do you currently have coronavirus symptoms?</h1>
-
-      <p class="govuk-body-m">This will help us track and trace the spread of coronavirus.</p>
-
-      <p>The main symptoms of coronavirus are:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li><strong>high temperature</strong> – this means you feel hot to touch on your chest or back (you do not need to measure your temperature)</li>
-        <li><strong>new, continuous cough</strong> – this means coughing a lot for more than an hour, or 3 or more coughing episodes in 24 hours (if you usually have a cough, it may be worse than usual)</li>
-        <li><strong>loss or change to your sense of smell or taste</strong> – this means you've noticed you cannot smell or taste anything, or things smell or taste different to normal</li>
-      </ul>
-
-      <p class="govuk-body-m">Most people with coronavirus have at least one of these symptoms.</p>
-
-      <form class="form" action="/v1/registration/test-selection" method="post">
+      <form action="/{{version}}/registration/test-selection" method="post">
 
         <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset">
+          <fieldset class="govuk-fieldset" aria-describedby="symptoms-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                Do you currently have coronavirus symptoms?
+              </h1>
+            </legend>
+            <span id="symptoms-hint" class="govuk-hint">
+              This will help us track and trace the spread of coronavirus.
+              The main symptoms of coronavirus are:
+              <ul>
+                <li><strong>high temperature</strong> – this means you feel hot to touch on your chest or back (you do not need to measure your temperature)</li>
+                <li><strong>new, continuous cough</strong> – this means coughing a lot for more than an hour, or 3 or more coughing episodes in 24 hours (if you usually have a cough, it may be worse than usual)</li>
+                <li><strong>loss or change to your sense of smell or taste</strong> – this means you've noticed you cannot smell or taste anything, or things smell or taste different to normal</li>
+              </ul>
+              Most people with coronavirus have at least one of these symptoms.
+            </span>
             <div class="govuk-radios">
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="do-you-have-symptoms-1" name="do-you-have-symptoms" type="radio" value="Yes" {{ checked("do-you-have-symptoms", "Yes") }}>

--- a/app/views/v1/registration/email-address.html
+++ b/app/views/v1/registration/email-address.html
@@ -39,7 +39,7 @@
                   <label class="govuk-label" for="email-address">
                     Email address
                   </label>
-                  <input class="govuk-input" id="email-address" name="email-address" type="text" value={{ data['mobile-phone-number'] }}>
+                  <input class="govuk-input" id="email-address" name="email-address" type="text" value={{ data['email-address'] }}>
                 </div>
               </div>
               <div class="govuk-radios__item">

--- a/app/views/v1/registration/email-address.html
+++ b/app/views/v1/registration/email-address.html
@@ -1,11 +1,13 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  Do you have an email address where you can receive your coronavirus results?
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/v1/registration/mobile-number">Back</a>
+  <a class="govuk-back-link" href="/{{version}}/registration/mobile-number">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -13,33 +15,37 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Do you have an email address where you can receive your coronavirus results?</h1>
-
-      <p class="govuk-body-m">To apply for a coronavirus test online, you need an email address or mobile phone number. If you don’t have an email address, you can still get a coronavirus test.</p>
-
-      <form class="form" action="/v1/registration/occupation" method="post">
+      <form action="/{{version}}/registration/occupation" method="post">
 
         <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset">
-            <div class="govuk-radios">
+          <fieldset class="govuk-fieldset" aria-describedby="email-address-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                Do you have an email address where you can receive your coronavirus results?
+              </h1>
+            </legend>
+            <span id="email-address-hint" class="govuk-hint">
+              To apply for a coronavirus test online, you need an email address or mobile phone number. If you don’t have an email address, you can still get a coronavirus test.
+            </span>
+            <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="email-1" name="email" type="radio" value="Yes" {{ checked("email", "Yes") }}>
+                <input class="govuk-radios__input" id="email-1" name="email" type="radio" value="Yes" data-aria-controls="conditional-email-address" {{ checked("email", "Yes") }}>
                 <label class="govuk-label govuk-radios__label" for="email-1">
-                    Yes, I have an email address where I can receive my results
+                  Yes, I have an email address where I can receive my results
                 </label>
-                <div class="govuk-inset-text input-box">
-                    <div class="govuk-form-group">
-                        <label class="govuk-label" for="email-address">
-                          Email address
-                        </label>
-                        <input class="govuk-input" id="email-address" name="email-address" type="text" value={{ data['email-address'] }}>
-                    </div>
+              </div>
+              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-email-address">
+                <div class="govuk-form-group">
+                  <label class="govuk-label" for="email-address">
+                    Email address
+                  </label>
+                  <input class="govuk-input" id="email-address" name="email-address" type="text" value={{ data['mobile-phone-number'] }}>
                 </div>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="email-2" name="email" type="radio" value="No" {{ checked("email", "No") }}>
                 <label class="govuk-label govuk-radios__label" for="email-2">
-                    No, I don’t have an email address
+                  No, I don’t have an email address
                 </label>
               </div>
             </div>

--- a/app/views/v1/registration/ethnic-background.html
+++ b/app/views/v1/registration/ethnic-background.html
@@ -1,11 +1,13 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  Which one best describes your Asian or Asian British background? - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/v1/registration/ethnic-group">Back</a>
+  <a class="govuk-back-link" href="/{{version}}/registration/ethnic-group">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -13,14 +15,18 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Which one best describes your Asian or Asian British background?</h1>
-
-      <p class="govuk-body-m">This will help us understand how coronavirus is affecting people of different ethnic backgrounds.</p>
-
-      <form class="form" action="/v1/registration/previously-tested" method="post">
+      <form class="form" action="/{{version}}/registration/previously-tested" method="post">
 
         <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset">
+          <fieldset class="govuk-fieldset" aria-describedby="ethnic-background-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                Which one best describes your Asian or Asian British background?
+              </h1>
+            </legend>
+            <span id="ethnic-background-hint" class="govuk-hint">
+              This will help us understand how coronavirus is affecting people of different ethnic backgrounds.
+            </span>
             <div class="govuk-radios">
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="ethnic-background-1" name="ethnic-background" type="radio" value="Bangladeshi" {{ checked("ethnic-background", "Bangladeshi") }}>
@@ -29,38 +35,39 @@
                 </label>
               </div>
               <div class="govuk-radios__item">
-                 <input class="govuk-radios__input" id="ethnic-background-2" name="ethnic-background" type="radio" value="Chinese" {{ checked("ethnic-background", "Chinese") }}>
-                 <label class="govuk-label govuk-radios__label" for="ethnic-background-2">
-                   Chinese
-                 </label>
+                <input class="govuk-radios__input" id="ethnic-background-2" name="ethnic-background" type="radio" value="Chinese" {{ checked("ethnic-background", "Chinese") }}>
+                <label class="govuk-label govuk-radios__label" for="ethnic-background-2">
+                  Chinese
+                </label>
               </div>
               <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="ethnic-background-3" name="ethnic-background" type="radio" value="Indian" {{ checked("ethnic-background", "Indian") }}>
-                  <label class="govuk-label govuk-radios__label" for="ethnic-background-3">
-                    Indian
-                  </label>
+                <input class="govuk-radios__input" id="ethnic-background-3" name="ethnic-background" type="radio" value="Indian" {{ checked("ethnic-background", "Indian") }}>
+                <label class="govuk-label govuk-radios__label" for="ethnic-background-3">
+                  Indian
+                </label>
               </div>
               <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="ethnic-background-4" name="ethnic-background" type="radio" value="Pakistani" {{ checked("ethnic-background", "Pakistani") }}>
-                  <label class="govuk-label govuk-radios__label" for="ethnic-background-4">
-                    Pakistani
-                  </label>
+                <input class="govuk-radios__input" id="ethnic-background-4" name="ethnic-background" type="radio" value="Pakistani" {{ checked("ethnic-background", "Pakistani") }}>
+                <label class="govuk-label govuk-radios__label" for="ethnic-background-4">
+                  Pakistani
+                </label>
               </div>
               <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="ethnic-background-5" name="ethnic-background" type="radio" value="Another Asian background" {{ checked("ethnic-background", "Another Asian background") }}>
-                  <label class="govuk-label govuk-radios__label" for="ethnic-background-5">
-                      Another Asian background
-                  </label>
+                <input class="govuk-radios__input" id="ethnic-background-5" name="ethnic-background" type="radio" value="Another Asian background" {{ checked("ethnic-background", "Another Asian background") }}>
+                <label class="govuk-label govuk-radios__label" for="ethnic-background-5">
+                  Another Asian background
+                </label>
               </div>
   
-              <p class="govuk-body-m">or</p>
+              <div class="govuk-radios__divider">or</div>
   
               <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="ethnic-background-6" name="ethnic-background" type="radio" value="Prefer not to say" {{ checked("ethnic-background", "Prefer not to say") }}>
-                  <label class="govuk-label govuk-radios__label" for="ethnic-background-6">
-                      Prefer not to say
-                  </label>
+                <input class="govuk-radios__input" id="ethnic-background-6" name="ethnic-background" type="radio" value="Prefer not to say" {{ checked("ethnic-background", "Prefer not to say") }}>
+                <label class="govuk-label govuk-radios__label" for="ethnic-background-6">
+                  Prefer not to say
+                </label>
               </div>
+  
             </div>
           </fieldset>
         </div>  

--- a/app/views/v1/registration/ethnic-group.html
+++ b/app/views/v1/registration/ethnic-group.html
@@ -1,11 +1,13 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  What is your ethnic group? - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/v1/registration/gender">Back</a>
+  <a class="govuk-back-link" href="/{{version}}/registration/gender">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -13,64 +15,74 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">What is your ethnic group?</h1>
-
-      <p class="govuk-body-m">This will help us understand how coronavirus is affecting people of different ethnic backgrounds.</p>
-
-      <form class="form" action="/v1/registration/ethnic-background" method="post">
+      <form action="/{{version}}/registration/ethnic-background" method="post">
 
         <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset">
+          <fieldset class="govuk-fieldset" aria-describedby="ethnic-group-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                What is your ethnic group?
+              </h1>
+            </legend>
+            <span id="ethnic-group-hint" class="govuk-hint">
+              This will help us understand how coronavirus is affecting people of different ethnic backgrounds.
+            </span>
             <div class="govuk-radios">
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="ethnic-group-1" name="ethnic-group" type="radio" value="Asian or Asian British" {{ checked("ethnic-group", "Asian or Asian British") }}>
+                <input class="govuk-radios__input" id="ethnic-group-1" name="ethnic-group" type="radio" value="Asian or Asian British" {{ checked("ethnic-group", "Asian or Asian British") }} aria-describedby="asian-british-hint">
                 <label class="govuk-label govuk-radios__label" for="ethnic-group-1">
-                  <strong>Asian or Asian British</strong>
-                  </br>
+                  Asian or Asian British
+                </label>
+                <span id="asian-british-hint" class="govuk-hint govuk-radios__hint">
                   Includes any Asian background, for example, Bangladeshi, Chinese, Indian, Pakistani or other East or South Asian
+                </span>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="ethnic-group-2" name="ethnic-group" type="radio" value="Black, African, Black British or Caribbean" {{ checked("ethnic-group", "Black, African, Black British or Caribbean") }} aria-describedby="black-african-black-british-caribbean-hint">
+                <label class="govuk-label govuk-radios__label" for="ethnic-group-2">
+                  Black, African, Black British or Caribbean
+                </label>
+                <span id="black-african-black-british-caribbean-hint" class="govuk-hint govuk-radios__hint">
+                  Includes any Black background
+                </span>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="ethnic-group-3" name="ethnic-group" type="radio" value="Mixed or multiple ethnic groups" {{ checked("ethnic-group", "Mixed or multiple ethnic groups") }} aria-describedby="mixed-hint">
+                <label class="govuk-label govuk-radios__label" for="ethnic-group-3">
+                  Mixed or multiple ethnic groups
+                </label>
+                <span id="mixed-hint" class="govuk-hint govuk-radios__hint">
+                  Includes any mixed background
+                </span>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="ethnic-group-4" name="ethnic-group" type="radio" value="White" {{ checked("ethnic-group", "White") }} aria-describedby="white-hint">
+                <label class="govuk-label govuk-radios__label" for="ethnic-group-4">
+                  White
+                </label>
+                <span id="white-hint" class="govuk-hint govuk-radios__hint">
+                  Includes any White background
+                </span>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="ethnic-group-5" name="ethnic-group" type="radio" value="Another ethnic group" {{ checked("ethnic-group", "Another ethnic group") }} aria-describedby="other-hint">
+                <label class="govuk-label govuk-radios__label" for="ethnic-group-5">
+                  Another ethnic group
+                </label>
+                <span id="other-hint" class="govuk-hint govuk-radios__hint">
+                  Includes any other ethnic group, for example, Arab
+                </span>
+              </div>
+  
+              <div class="govuk-radios__divider">or</div>
+  
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="ethnic-group-6" name="ethnic-group" type="radio" value="Prefer not to say" {{ checked("ethnic-group", "Prefer not to say") }}>
+                <label class="govuk-label govuk-radios__label" for="ethnic-group-6">
+                  Prefer not to say
                 </label>
               </div>
-              <div class="govuk-radios__item">
-                 <input class="govuk-radios__input" id="ethnic-group-2" name="ethnic-group" type="radio" value="Black, African, Black British or Caribbean" {{ checked("ethnic-group", "Black, African, Black British or Caribbean") }}>
-                 <label class="govuk-label govuk-radios__label" for="ethnic-group-2">
-                   <strong>Black, African, Black British or Caribbean</strong>
-                   </br>
-                   Includes any Black background
-                 </label>
-              </div>
-              <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="ethnic-group-3" name="ethnic-group" type="radio" value="Mixed or multiple ethnic groups" {{ checked("ethnic-group", "Mixed or multiple ethnic groups") }}>
-                  <label class="govuk-label govuk-radios__label" for="ethnic-group-3">
-                    <strong>Mixed or multiple ethnic groups</strong>
-                    </br>
-                    Includes any mixed background
-                  </label>
-              </div>
-              <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="ethnic-group-4" name="ethnic-group" type="radio" value="White" {{ checked("ethnic-group", "White") }}>
-                  <label class="govuk-label govuk-radios__label" for="ethnic-group-4">
-                    <strong>White</strong>
-                    </br>
-                    Includes any White background
-                  </label>
-              </div>
-              <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="ethnic-group-5" name="ethnic-group" type="radio" value="Another ethnic group" {{ checked("ethnic-group", "Another ethnic group") }}>
-                  <label class="govuk-label govuk-radios__label" for="ethnic-group-5">
-                    <strong>Another ethnic group</strong>
-                    </br>
-                    Includes any other ethnic group, for example, Arab
-                  </label>
-              </div>
-  
-              <p class="govuk-body-m">or</p>
-  
-              <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="ethnic-group-6" name="ethnic-group" type="radio" value="Prefer not to say" {{ checked("ethnic-group", "Prefer not to say") }}>
-                  <label class="govuk-label govuk-radios__label" for="ethnic-group-6">
-                      Prefer not to say
-                  </label>
-              </div>
+              
             </div>
           </fieldset>
         </div>

--- a/app/views/v1/registration/gender.html
+++ b/app/views/v1/registration/gender.html
@@ -1,11 +1,13 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  What's your gender? - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/v1/registration/working-circumstances">Back</a>
+  <a class="govuk-back-link" href="/{{version}}/registration/working-circumstances">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -13,12 +15,15 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">What's your gender?</h1>
-
-      <form class="form" action="/v1/registration/ethnic-group" method="post">
-
+      <form action="/{{version}}/registration/ethnic-group" method="post">
+      
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                What's your gender?
+              </h1>
+            </legend>
             <div class="govuk-radios">
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="gender-1" name="gender" type="radio" value="Male" {{ checked("gender", "Male") }}>

--- a/app/views/v1/registration/household.html
+++ b/app/views/v1/registration/household.html
@@ -1,11 +1,13 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  Has anyone else in your household tested positive for coronavirus before? - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/v1/registration/previously-tested-result">Back</a>
+  <a class="govuk-back-link" href="/{{version}}/registration/previously-tested-result">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -13,23 +15,26 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Has anyone else in your household tested positive for coronavirus before?</h1>
-
-      <form class="form" action="/v1/registration/immune-status" method="post">
+      <form action="/{{version}}/registration/immune-status" method="post">
 
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                Has anyone else in your household tested positive for coronavirus before?
+              </h1>
+            </legend>
             <div class="govuk-radios">
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="household-1" name="household" type="radio" value="Yes" {{ checked("household", "Yes") }}>
                 <label class="govuk-label govuk-radios__label" for="household-1">
-                    Yes
+                  Yes
                 </label>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="household-2" name="household" type="radio" value="No" {{ checked("household", "No") }}>
                 <label class="govuk-label govuk-radios__label" for="household-2">
-                    No
+                  No
                 </label>
               </div>
             </div>

--- a/app/views/v1/registration/immune-status.html
+++ b/app/views/v1/registration/immune-status.html
@@ -1,11 +1,13 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  Are there any factors, such as medical conditions, which affect your immune status? - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/v1/registration/household">Back</a>
+  <a class="govuk-back-link" href="/{{version}}/registration/household">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -13,25 +15,26 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Immune status</h1>
-
-      <p class="govuk-body-m">Are there any factors, such as medical conditions, which affect your immune status?</p>
-
-      <form class="form" action="/v1/registration/smartphone" method="post">
+      <form class="form" action="/{{version}}/registration/smartphone" method="post">
 
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                Are there any factors, such as medical conditions, which affect your immune status?
+              </h1>
+            </legend>
             <div class="govuk-radios">
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="immune-status-1" name="immune-status" type="radio" value="Yes" {{ checked("immune-status", "Yes") }}>
                 <label class="govuk-label govuk-radios__label" for="immune-status-1">
-                    Yes
+                  Yes
                 </label>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="immune-status-2" name="immune-status" type="radio" value="No" {{ checked("immune-status", "No") }}>
                 <label class="govuk-label govuk-radios__label" for="immune-status-2">
-                    No
+                  No
                 </label>
               </div>
             </div>

--- a/app/views/v1/registration/index.html
+++ b/app/views/v1/registration/index.html
@@ -1,7 +1,9 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  Get a coronavirus test - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
@@ -13,22 +15,18 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Get a coronavirus test</h1>
+      <h1 class="govuk-heading-l">Get a coronavirus test</h1>
+      <p class="govuk-body">Use this service to check what tests you are eligible for and how you want to be tested.</p>
 
-      <p class="govuk-body-l">Use this service to check what tests you are eligible for and how you want to be tested.</p>
-
-      <p class="govuk-body-l"><strong>What tests are available</strong></p>
-      
-      <p>There are now two types of test for coronavirus:</p>
+      <h2 class="govuk-heading-m">What tests are available</h2>
+      <p class="govuk-body">There are now two types of test for coronavirus:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>An antigen test: this tells you if you currently have coronavirus</li>
         <li>An antibody test:  this tells you if you have had coronavirus in the past</li>
       </ul>
 
-      <br>
-      <p class="govuk-body-l"><strong>Who can ask for a test</strong></p>
-      
-      <p>You can ask for a test if:</p>
+      <h2 class="govuk-heading-m">Who can ask for a test</h2>
+      <p class="govuk-body">You can ask for a test if:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>you and others in your home if you have coronavirus symptoms now (a high temperature, a new, continuous cough, or a loss or change to your sense of smell or taste)</li>
         <li>you and others in your home if you have previously tested positive for coronavirus, or have had coronavirus symptoms and weren’t tested</li>
@@ -37,11 +35,12 @@
         <li>If you're asking for a test for someone else, and the person is aged 13 or over, check they're happy for you to ask for a test for them.</li>
       </ul>
 
-      <form class="form" action="/v1/registration/do-you-have-symptoms" method="post">
-
-        <button class="govuk-button" data-module="govuk-button">Continue</button>
-
-      </form>
+      <a href="/{{version}}/registration/do-you-have-symptoms" role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
+        Start now
+        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+          <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+        </svg>
+      </a>
 
     </div>
   </div>

--- a/app/views/v1/registration/mobile-number.html
+++ b/app/views/v1/registration/mobile-number.html
@@ -39,7 +39,10 @@
                   <label class="govuk-label" for="mobile-phone-number">
                     Phone number
                   </label>
-                  <input class="govuk-input govuk-!-width-one-third" id="mobile-phone-number" name="mobile-phone-number" type="tel" value={{ data['mobile-phone-number'] }}>
+                  <span id="conditional-mobile-hint" class="govuk-hint">
+                    Make sure you’re happy for your test results to go to this mobile number
+                  </span>
+                  <input class="govuk-input govuk-!-width-one-third" id="mobile-phone-number" name="mobile-phone-number" type="tel" value={{ data['mobile-phone-number'] }} aria-describedby="conditional-mobile-hint">
                 </div>
               </div>
               <div class="govuk-radios__item">

--- a/app/views/v1/registration/mobile-number.html
+++ b/app/views/v1/registration/mobile-number.html
@@ -1,11 +1,13 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  Do you have a mobile phone number where you can receive your coronavirus results? - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/v1/registration/date-of-birth">Back</a>
+  <a class="govuk-back-link" href="/{{version}}/registration/date-of-birth">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -13,34 +15,37 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Do you have a mobile phone number where you can receive your coronavirus results?</h1>
-
-      <p class="govuk-body-m">To apply for a coronavirus test online, you need an email address or mobile phone number. If you don’t have a mobile phone number, you can still get a coronavirus test. </p>
-
-      <form class="form" action="/v1/registration/email-address" method="post">
+      <form action="/{{version}}/registration/email-address" method="post">
 
         <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset">
-            <div class="govuk-radios">
+          <fieldset class="govuk-fieldset" aria-describedby="mobile-number-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                Do you have a mobile phone number where you can receive your coronavirus results?
+              </h1>
+            </legend>
+            <span id="mobile-number-hint" class="govuk-hint">
+              To apply for a coronavirus test online, you need an email address or mobile phone number. If you don’t have a mobile phone number, you can still get a coronavirus test.
+            </span>
+            <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="mobile-number-1" name="mobile-number" type="radio" value="Yes" {{ checked("mobile-number", "Yes") }}>
+                <input class="govuk-radios__input" id="mobile-number-1" name="mobile-number" type="radio" value="Yes" data-aria-controls="conditional-mobile-number" {{ checked("mobile-number", "No") }}>
                 <label class="govuk-label govuk-radios__label" for="mobile-number-1">
-                    Yes, I have a mobile phone number where I can receive my results
+                  Yes, I have a mobile phone number where I can receive my results
                 </label>
-                <div class="govuk-inset-text input-box">
-                    <p class="govuk-body-m">Make sure you’re happy for your test results to go to this mobile number</p>
-                    <div class="govuk-form-group">
-                        <label class="govuk-label" for="mobile-phone-number">
-                          Mobile number
-                        </label>
-                        <input class="govuk-input" id="mobile-phone-number" name="mobile-phone-number" type="text" value={{ data['mobile-phone-number'] }}>
-                    </div>
+              </div>
+              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-mobile-number">
+                <div class="govuk-form-group">
+                  <label class="govuk-label" for="mobile-phone-number">
+                    Phone number
+                  </label>
+                  <input class="govuk-input govuk-!-width-one-third" id="mobile-phone-number" name="mobile-phone-number" type="tel" value={{ data['mobile-phone-number'] }}>
                 </div>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="mobile-number-2" name="mobile-number" type="radio" value="No" {{ checked("mobile-number", "No") }}>
                 <label class="govuk-label govuk-radios__label" for="mobile-number-2">
-                    No, I don’t have a mobile phone number
+                  No, I don’t have a mobile phone number
                 </label>
               </div>
             </div>
@@ -55,3 +60,4 @@
   </div>
 
 {% endblock %}
+

--- a/app/views/v1/registration/name.html
+++ b/app/views/v1/registration/name.html
@@ -1,7 +1,9 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  What's your name? - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
@@ -13,22 +15,22 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">What's your name?</h1>
+      <h1 class="govuk-heading-l">What's your name?</h1>
 
-      <form class="form" action="/v1/registration/date-of-birth" method="post">
+      <form action="/{{version}}/registration/date-of-birth" method="post">
 
         <fieldset class="govuk-fieldset">
         
           <div class="govuk-form-group">
             <label class="govuk-label" for="first-name">
-              First Name
+              First name
             </label>
             <input class="govuk-input govuk-!-width-two-thirds" id="first-name" name="first-name" type="text" value={{ data['first-name'] }}>
           </div>
 
           <div class="govuk-form-group">
             <label class="govuk-label" for="last-name">
-              Last Name
+              Last name
             </label>
             <input class="govuk-input govuk-!-width-two-thirds" id="last-name" name="last-name" type="text" value={{ data['last-name'] }}>
           </div>

--- a/app/views/v1/registration/occupation.html
+++ b/app/views/v1/registration/occupation.html
@@ -1,7 +1,9 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  What is your occupation? - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
@@ -13,19 +15,26 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">What is your occupation?</h1>
-
-      <form class="form" action="/v1/registration/working-circumstances" method="post">
+      <form action="/{{version}}/registration/working-circumstances" method="post">
 
         <fieldset class="govuk-fieldset">
-        
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading">
+              What is your occupation?
+            </h1>
+          </legend>
+
           <div class="govuk-form-group">
             <label class="govuk-label" for="occupation">
-                Select an option from the list
+              Select an option from the list
             </label>
-            <input class="govuk-input govuk-!-width-two-thirds" id="occupation" name="occupation" type="text" value={{ data['occupation'] }}>
+            <select class="govuk-select" id="occupation" name="occupation">
+              <option value="Item 1">Item 1</option>
+              <option value="Item 2">Item 2</option>
+              <option value="Item 3">Item 3</option>
+            </select>
           </div>
-        
+
         </fieldset>
 
         <button class="govuk-button" data-module="govuk-button">Continue</button>

--- a/app/views/v1/registration/postcode.html
+++ b/app/views/v1/registration/postcode.html
@@ -1,11 +1,13 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  What is your postcode? - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/v1/registration/smartphone">Back</a>
+  <a class="govuk-back-link" href="/{{version}}/registration/smartphone">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -13,21 +15,23 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Enter a postcode</h1>
+      <form action="/{{version}}/registration/check-your-answers" method="post">
 
-      <p class="govuk-body-m">We need this to know if you are near a test site</p>
-
-      <form class="form" action="/v1/registration/check-your-answers" method="post">
-
-        <fieldset class="govuk-fieldset">
-        
+        <fieldset class="govuk-fieldset" aria-describedby="post-code-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading">
+              What is your postcode?
+            </h1>
+          </legend>
+          <span id="post-code-hint" class="govuk-hint">
+            We need this to know if you are near a test site
+          </span>
           <div class="govuk-form-group">
-            <label class="govuk-label" for="postcode">
+            <label class="govuk-label" for="test-postcode">
               Postcode
             </label>
-            <input class="govuk-input govuk-!-width-two-thirds" id="postcode" name="postcode" type="text" value={{ data['postcode'] }}>
+            <input class="govuk-input govuk-input--width-10" id="test-postcode" name="test-postcode" type="text" autocomplete="postal-code" value="{{ data['test-postcode'] }}">
           </div>
-        
         </fieldset>
 
         <button class="govuk-button" data-module="govuk-button">Continue</button>

--- a/app/views/v1/registration/previously-tested-date.html
+++ b/app/views/v1/registration/previously-tested-date.html
@@ -1,11 +1,13 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  When was your previous coronavirus test? - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/v1/registration/previously-tested">Back</a>
+  <a class="govuk-back-link" href="/{{version}}/registration/previously-tested">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -13,17 +15,18 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">When was your previous coronavirus test?</h1>
-
-      <p class="govuk-body-m">If you have had multiple tests, enter the date of your most recent test.</p>
-
-      <form class="form" action="/v1/registration/previously-tested-result" method="post">
+      <form action="/{{version}}/registration/previously-tested-result" method="post">
 
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset" role="group" aria-describedby="previous-test-date-hint">
-            <span class="govuk-body-m">Enter the date</span>
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                When was your previous coronavirus test?
+              </h1>
+            </legend>
             <span id="previous-test-date-hint" class="govuk-hint">
-                Use the format DD MM YYYY, for example 15 04 2020
+              If you have had multiple tests, enter the date of your most recent test.<br><br>
+              For example 15 04 2020
             </span>
             <div class="govuk-date-input" id="previously-tested-date">
               <div class="govuk-date-input__item">

--- a/app/views/v1/registration/previously-tested-result.html
+++ b/app/views/v1/registration/previously-tested-result.html
@@ -1,11 +1,13 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  What was the result of your coronavirus test? - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/v1/registration/previously-tested-date">Back</a>
+  <a class="govuk-back-link" href="/{{verssion}}/registration/previously-tested-date">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -13,14 +15,18 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">What was the result of your coronavirus test?</h1>
-
-      <p class="govuk-body-m">If you have had multiple tests and any one of them was positive, select ‘I tested positive for coronavirus’</p>
-
-      <form class="form" action="/v1/registration/household" method="post">
+      <form class="form" action="/{{version}}/registration/household" method="post">
 
         <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset">
+          <fieldset class="govuk-fieldset" aria-describedby="result-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                What was the result of your coronavirus test?
+              </h1>
+            </legend>
+            <span id="result-hint" class="govuk-hint">
+              If you have had multiple tests and any one of them was positive, select ‘I tested positive for coronavirus’
+            </span>
             <div class="govuk-radios">
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="previously-tested-result-1" name="previously-tested-result" type="radio" value="Positive" {{ checked("previously-tested-result", "Positive") }}>

--- a/app/views/v1/registration/previously-tested.html
+++ b/app/views/v1/registration/previously-tested.html
@@ -1,11 +1,13 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  >Have you been tested for coronavirus before? - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/v1/registration/ethnic-background">Back</a>
+  <a class="govuk-back-link" href="/{{version}}/registration/ethnic-background">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -13,12 +15,15 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Have you been tested for coronavirus before?</h1>
-
-      <form class="form" action="/v1/registration/previously-tested-date" method="post">
+      <form action="/{{version}}/registration/previously-tested-date" method="post">
 
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                Have you been tested for coronavirus before?
+              </h1>
+            </legend>
             <div class="govuk-radios">
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="previously-tested-1" name="previously-tested" type="radio" value="Yes" {{ checked("previously-tested", "Yes") }}>

--- a/app/views/v1/registration/smartphone.html
+++ b/app/views/v1/registration/smartphone.html
@@ -1,11 +1,13 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  Do you or someone you live with have a smartphone? - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/v1/registration/immune-status">Back</a>
+  <a class="govuk-back-link" href="/{{version}}/registration/immune-status">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -13,27 +15,30 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Do you or someone you live with have a smartphone?</h1>
-
-      <p class="govuk-body-m">Answer ‘Yes’ if you or someone in your household has a smartphone that is able to download an iOS or Android app and have a working camera.</p>
-
-      <p class="govuk-body-m">If you do not have a smartphone, you will still be able to take an antibody test.</p>
-
-      <form class="form" action="/v1/registration/postcode" method="post">
+      <form class="form" action="/{{version}}/registration/postcode" method="post">
 
         <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset">
+          <fieldset class="govuk-fieldset" aria-describedby="smartphone-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                Do you or someone you live with have a smartphone?
+              </h1>
+            </legend>
+            <span id="smartphone-hint" class="govuk-hint">
+              Answer ‘Yes’ if you or someone in your household has a smartphone that is able to download an iOS or Android app and have a working camera.<br><br>
+              If you do not have a smartphone, you will still be able to take an antibody test.
+            </span>
             <div class="govuk-radios">
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="smartphone-1" name="smartphone" type="radio" value="Yes" {{ checked("smartphone", "Yes") }}>
                 <label class="govuk-label govuk-radios__label" for="smartphone-1">
-                    Yes
+                  Yes
                 </label>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="smartphone-2" name="smartphone" type="radio" value="No" {{ checked("smartphone", "No") }}>
                 <label class="govuk-label govuk-radios__label" for="smartphone-2">
-                    No
+                  No
                 </label>
               </div>
             </div>

--- a/app/views/v1/registration/test-selection.html
+++ b/app/views/v1/registration/test-selection.html
@@ -1,11 +1,13 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  Do you want to apply for an antigen test or an antibody test? - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/v1/registration/do-you-have-symptoms">Back</a>
+  <a class="govuk-back-link" href="/{{version}}/registration/do-you-have-symptoms">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -13,16 +15,21 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Do you want to apply for an antigen test or an antibody test?</h1>
-
-      <p class="govuk-body-m">An antigen test will tell you if you currently have coronavirus. You should choose an antigen test if you suspect you currently have coronavirus and as a result you are self-isolating.</p>
-
-      <p class="govuk-body-m">An antibody test will tell you if you have ever had coronavirus. You should choose an antibody test if you think you may have had coronavirus in the past. </p>
-
-      <form class="form" action="/v1/registration/blood-sample" method="post">
+      <form action="/{{version}}/registration/blood-sample" method="post">
 
         <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset">
+          <fieldset class="govuk-fieldset" aria-describedby="antigen-hint antibody-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                Do you want to apply for an antigen test or an antibody test?
+              </h1>
+            </legend>
+            <span id="antigen-hint" class="govuk-hint">
+              An antigen test will tell you if you currently have coronavirus. You should choose an antigen test if you suspect you currently have coronavirus and as a result you are self-isolating.
+            </span>
+            <span id="antibody-hint" class="govuk-hint">
+              An antibody test will tell you if you have ever had coronavirus. You should choose an antibody test if you think you may have had coronavirus in the past.
+            </span>
             <div class="govuk-radios">
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="test-selection-1" name="test-selection" type="radio" value="Antigen test" {{ checked("test-selection", "Antigen test") }}>

--- a/app/views/v1/registration/working-circumstances.html
+++ b/app/views/v1/registration/working-circumstances.html
@@ -1,11 +1,13 @@
+{% set version = "v1" %}
+
 {% extends "includes/layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  What are your working circumstances? - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/v1/registration/occupation">Back</a>
+  <a class="govuk-back-link" href="/{{version}}/registration/occupation">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -13,19 +15,25 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">What are your working circumstances?</h1>
-
-      <form class="form" action="/v1/registration/gender" method="post">
+      <form action="/{{version}}/registration/gender" method="post">
 
         <fieldset class="govuk-fieldset">
-        
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading">
+              What are your working circumstances?
+            </h1>
+          </legend>
+
           <div class="govuk-form-group">
             <label class="govuk-label" for="working-circumstances">
-                Select an option from the list
+              Select an option from the list
             </label>
-            <input class="govuk-input govuk-!-width-two-thirds" id="working-circumstances" name="working-circumstances" type="text" value={{ data['working-circumstances'] }}>
+            <select class="govuk-select" id="working-circumstances" name="working-circumstances">
+              <option value="Item 1">Item 1</option>
+              <option value="Item 2">Item 2</option>
+              <option value="Item 3">Item 3</option>
+            </select>
           </div>
-        
         </fieldset>
 
         <button class="govuk-button" data-module="govuk-button">Continue</button>


### PR DESCRIPTION
- Add page titles to each page
- Add version numbers to pages and pathss so its easier to update later on
- Move the headings inside the fieldset using the legend element so that it is semantic and follows the GOV.UK design system
- Use the correct markup for hint text from the GOV.UK design system
- Use the correct markup for 'or' divider within Radios from the GOV.UK design system
- Update the markup for conditional reveals and remove custom jQuery for conditional reveals, the GOV.UK frontend has this included (https://design-system.service.gov.uk/components/radios/#conditionally-revealing-content)
- Use a select component when asking someone to select from a list
- Use the correct markup for button on the start page